### PR TITLE
Added properties argument to Exec

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -20,7 +20,7 @@ func (p Platypus) Login(username string, password string) error {
 		Password:  password,
 	}
 
-	res, err := p.Exec("Login", params)
+	res, err := p.Exec("Login", params, nil)
 	if err != nil {
 		return err
 	}

--- a/basictypes.go
+++ b/basictypes.go
@@ -27,7 +27,7 @@ type DataBlock struct {
 	Username     string             `xml:"username"`
 	Password     string             `xml:"password"`
 	Logintype    string             `xml:"logintype"`
-	Properties   string             `xml:"properties"`
+	Properties   interface{}        `xml:"properties"`
 	Parameters   interface{}        `xml:"parameters"`
 	ResponseCode string             `xml:"response_code,omitempty"`
 	ResponseText string             `xml:"response_text,omitempty"`

--- a/connection.go
+++ b/connection.go
@@ -78,13 +78,14 @@ func (p Platypus) getConn() {
 }
 
 // Exec calls the WOW API method named in action with a parameter struct.
-func (p Platypus) Exec(action string, params interface{}) (DataBlock, error) {
+func (p Platypus) Exec(action string, params interface{}, props interface{}) (DataBlock, error) {
 	reply := DataBlock{}
 
 	// prep request
 	db := p.newDataBlock()
 	db.Action = action
 	db.Parameters = params
+  db.Properties = props
 
 	b := Body{
 		Data: db,

--- a/scheduler.go
+++ b/scheduler.go
@@ -19,7 +19,7 @@ func (p Platypus) LastRun() (time.Time, error) {
 		Query:    "SELECT TOP 1 eventlog_etid, eventlog_result, eventlog_msg, eventlog_date FROM eventlog ORDER BY eventlog_date DESC",
 	}
 
-	res, err := p.Exec("SQL", params)
+	res, err := p.Exec("SQL", params, nil)
 	if err != nil {
 		return lastRun, err
 	}


### PR DESCRIPTION
Plat XML API sometimes places arguments to method calls in the <properties> section.
This would include those via an argument to the Exec method. 